### PR TITLE
docs: README.md -> Page not found at Team Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Ritchie Server
 
-This repository contains the integrations configured for the Ritchie [Team Version](https://docs.ritchiecli.io/software-architecture-1/team-version).
+This repository contains the integrations configured for the Ritchie [Team Version](https://docs.ritchiecli.io/getting-started/software-architecture#team-version).
 
 Currently, this repository is integrated with :
 


### PR DESCRIPTION
**- What I did**

Fix page not found at Team Version link.

**- How I did it**

Change link "https://docs.ritchiecli.io/software-architecture-1/team-version" to "https://docs.ritchiecli.io/getting-started/software-architecture#team-version"

**- How to verify it**

Click at Team Version link on readme.md

**- Description for the changelog**

Docs: Fix page not found at Team Version link.